### PR TITLE
npmとbrewにビルト用関数を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .shellspec
 node_modeles/
+.config/yarn/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,4 +34,9 @@
         "tests/ut/"
     ],
     "git.ignoreLimitWarning": true,
+    // シェルスクリプト設定
+    "[shellscript]": {
+        "editor.tabSize": 2,
+        "files.eol": "\n"
+    },
 }

--- a/.zshrc
+++ b/.zshrc
@@ -4,7 +4,11 @@ export PACKAGES="${DOTPATH}/packages.txt"
 # binスクリプト
 export PATH="${DOTPATH}/bin:$PATH"
 
-source ${DOTPATH}/lib/util.sh
+. "${DOTPATH}/lib/util.sh"
+. "${DOTPATH}/packages/npm.sh"
+
+# npmのセットアップ
+packages::npm::setup
 
 # -*- sh -*-
 #キーレイアウトの設定

--- a/.zshrc
+++ b/.zshrc
@@ -1,14 +1,21 @@
+# Pathの設定
 export DOTPATH="${HOME}/dotfiles"
 # インストールするパッケージ
 export PACKAGES="${DOTPATH}/packages.txt"
-# binスクリプト
+# shellの実行ファイルスクリプト
 export PATH="${DOTPATH}/bin:$PATH"
 
+# ライブラリのインポート
 . "${DOTPATH}/lib/util.sh"
 . "${DOTPATH}/packages/npm.sh"
+. "${DOTPATH}/packages/brew.sh"
 
-# npmのセットアップ
-packages::npm::setup
+# ビルド設定
+# npm
+Packages_Npm_build_path
+# brew
+packages::brew::build_path
+
 
 # -*- sh -*-
 #キーレイアウトの設定

--- a/packages/brew.sh
+++ b/packages/brew.sh
@@ -3,16 +3,27 @@
 # ライブラリ
 . ${DOTPATH}/lib/util.sh
 
+readonly declare arm64_homebrew_path='/opt/homebrew'
+
+function packages::brew::build_path() {
+# Summary: 環境変数のHomebrewのPATHを通す
+# Desc: マシンタイプ別に参照先のPATHを変更する
+
+    # マシンタイプ別に参照先を変更
+    if Lib_Util_is_arm64; then
+        export PATH="${arm64_homebrew_path}/bin:${PATH}"
+    fi
+}
 
 function packages::brew::setup_arm64() {
-# Summary: Homebrewをインストールする(M1 chip version)
+# Summary: Homebrewのインストールと利用準備をする(M1 chip version)
 # 
 # Returns:
 #   0: インストール処理の成功
 #   1: Homebrewがインストール済み
 
     # 移動するので現在パスの位置を記憶
-    local declare current_dir=$(pwd)
+    local readonly declare current_dir=$(pwd)
 
     # Homebrewがインストール済みの場合
     if Lib_Util_has brew; then
@@ -21,22 +32,13 @@ function packages::brew::setup_arm64() {
     fi
 
     # brewの実行ファイルが存在しない場合
-    if [[ ! -f /opt/homebrew/bin/brew ]]; then
+    if [[ ! -f "${arm64_homebrew_path}/bin/brew" ]]; then
         cd /opt
         sudo mkdir homebrew
-        sudo chown $USER /opt/homebrew
+        sudo chown $USER "${arm64_homebrew_path}"
         curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C homebrew
         cd "$current_dir"
     fi
-
-    # インストール後、環境変数にパスが通っていない場合
-    if ! Lib_Util_has brew ; then
-        echo 'export PATH=/opt/homebrew/bin:$PATH' >> "${HOME}/.zshrc"
-        source "${HOME}/.zshrc"
-    fi
-    
-    # 更新
-    brew update
     return 0
 }
 
@@ -54,7 +56,6 @@ function packages::brew::setup_x86_64() {
     fi
 
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || return 1
-
     return 0
 }
 

--- a/packages/nodenv_operator.sh
+++ b/packages/nodenv_operator.sh
@@ -1,7 +1,0 @@
-setup_nodenv() {
-    echo 'setup nodenv'
-    git clone git://github.com/nodenv/nodenv.git $PATH_NODENV && \
-    git clone https://github.com/nodenv/node-build.git ~/.nodenv/plugins/node-build && \
-    git clone https://github.com/nodenv/node-build-update-defs.git ~/.nodenv/plugins/node-build-update-defs && \
-    curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-doctor | bash
-}

--- a/packages/npm.sh
+++ b/packages/npm.sh
@@ -2,14 +2,17 @@
 
 . "${DOTPATH}/lib/util.sh"
 
-function packages::npm::setup() {
+# npmで管理するグローバルプレフィックスのパス
+readonly declare npm_global_path="${HOME}/.npm-global"
+
+function Packages_Npm_build_path() {
 # Summary: npmのセットアップをする
 # 
     # npmが存在する場合
     if Lib_Util_has 'npm'; then
-        # パーミッションの関係で環境によってはグローバルでインストールできないことがある
+        # パーミッションの関係で環境によってはグローバルでインストールできないことがあるため
         # デフォルトのインストール先を変更する
-        npm config set prefix "${HOME}/.npm-global"
-        export PATH="$HOME/.npm-global/bin:$PATH"
+        npm config set prefix "$npm_global_path"
+        export PATH="${npm_global_path}/bin:$PATH"
     fi
 }

--- a/packages/npm.sh
+++ b/packages/npm.sh
@@ -1,0 +1,15 @@
+# FileInfo: npmを管理する
+
+. "${DOTPATH}/lib/util.sh"
+
+function packages::npm::setup() {
+# Summary: npmのセットアップをする
+# 
+    # npmが存在する場合
+    if Lib_Util_has 'npm'; then
+        # パーミッションの関係で環境によってはグローバルでインストールできないことがある
+        # デフォルトのインストール先を変更する
+        npm config set prefix "${HOME}/.npm-global"
+        export PATH="$HOME/.npm-global/bin:$PATH"
+    fi
+}

--- a/spec/util_spec.sh
+++ b/spec/util_spec.sh
@@ -6,13 +6,11 @@ Describe 'util.sh'
   #   The output should equal 'example error'
   #   The status should eq 0
   # End
-
-   It 'get_os_type'
+  It 'output has param'
     When call Lib_Util_output 'test massage'
     The output should equal 'test massage'
     The status should eq 0
   End
-
   It 'get_os_type'
     When call Lib_Util_get_os_type
     The output should equal 'osx'
@@ -38,14 +36,14 @@ Describe 'util.sh'
     When call Lib_Util_is_bsd
     The status should eq 1
   End
-  It 'is_bash'
-    When call Lib_Util_is_bash
-    The status should eq 1
-  End
-  It 'is_zsh'
-    When call Lib_Util_is_zsh
-    The status should eq 0
-  End
+  # It 'is_bash'
+  #   When call Lib_Util_is_bash
+  #   The status should eq 1
+  # End
+  # It 'is_zsh'
+  #   When call Lib_Util_is_zsh
+  #   The status should eq 0
+  # End
   It 'is_fish'
     When call Lib_Util_is_fish
     The status should eq 1


### PR DESCRIPTION
##  環境変数のビルト用関数を作成。  

- `.vscode`の`setting.json`にシェルスクリプトの設定を追加
-  `pakcages/npm.sh`と`packages/brew.sh`にビルドパス用の関数を追加
-  上記関数作成に伴い、`brew.sh`の修正と`.zshrc`にビルドパス関数を追加